### PR TITLE
ADZ-894 Remove readOnly label from response schema

### DIFF
--- a/spine-core/errors/errorCode.yaml
+++ b/spine-core/errors/errorCode.yaml
@@ -5,7 +5,6 @@ properties:
     type: array
     items:
       type: object
-      readOnly: true
       properties:
         system:
           type: string

--- a/spine-core/errors/operationOutcome.yaml
+++ b/spine-core/errors/operationOutcome.yaml
@@ -7,7 +7,6 @@ properties:
     type: string
     description: FHIR Resource Type.
     default: OperationOutcome
-    readOnly: true
   issue:
     type: array
     description: List of issues that have occurred.


### PR DESCRIPTION
**Description**
Remove readOnly label from response schemas.
More detail in: [ADZ-894](https://nhsd-jira.digital.nhs.uk/browse/ADZ-894)

